### PR TITLE
Add a link to the rendered website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # hpsf.io
 
-HPSF website
+This repository is the GitHub Pages source code for the [HPSF](https://hpsf.io) website.
 
+It uses the [Hugo Scroll theme](https://themes.gohugo.io/themes/hugo-scroll/).


### PR DESCRIPTION
This is a minor PR to demonstrate that the DCO app is installed in the HPSFoundation GitHub Org.
The proposed update to the README.md is a non-production change to the hpsf.io website repo.